### PR TITLE
Feat: V-1.7.0 Implement player detail modal sheet

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "ir.miare.androidcodechallenge"
         minSdk 21
         targetSdk 35
-        versionCode 13
-        versionName "1.6.1"
+        versionCode 14
+        versionName "1.7.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/ir/miare/androidcodechallenge/presentation/league_data_list/LeagueSection.kt
+++ b/app/src/main/java/ir/miare/androidcodechallenge/presentation/league_data_list/LeagueSection.kt
@@ -2,11 +2,14 @@ package ir.miare.androidcodechallenge.presentation.league_data_list
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import ir.miare.androidcodechallenge.data.model.League
 import ir.miare.androidcodechallenge.data.model.LeagueData
@@ -17,16 +20,25 @@ import ir.miare.androidcodechallenge.presentation.util.MyFootMobTheme
 @Composable
 fun LeagueSection(
     leagueData: LeagueData,
-    onFollowClick: (Player) -> Unit
+    onFollowClick: (Player) -> Unit,
+    onPlayerClick: (Player) -> Unit
 ) {
     Column {
         Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
             text = "${leagueData.league.name} (${leagueData.league.country})",
-            style = MaterialTheme.typography.titleLarge
+            style = MaterialTheme.typography.titleLarge,
+            textAlign = TextAlign.Center
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(4.dp))
         leagueData.players.forEach { player ->
-            PlayerItem(player = player, onFollowClick = onFollowClick)
+            PlayerItem(
+                player = player,
+                onFollowClick = onFollowClick,
+                onClick = { onPlayerClick(player) }
+            )
             Spacer(modifier = Modifier.height(4.dp))
         }
     }
@@ -45,7 +57,9 @@ fun PreviewLeagueSection() {
                     Player.sampleData.copy(name = "Player 3"),
                     Player.sampleData.copy(name = "Player 4"),
                 )
-            )
-        ) {}
+            ),
+            onFollowClick = {},
+            onPlayerClick = {}
+        )
     }
 }

--- a/app/src/main/java/ir/miare/androidcodechallenge/presentation/league_data_list/PlayerItem.kt
+++ b/app/src/main/java/ir/miare/androidcodechallenge/presentation/league_data_list/PlayerItem.kt
@@ -1,13 +1,12 @@
 package ir.miare.androidcodechallenge.presentation.league_data_list
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,37 +20,26 @@ import ir.miare.androidcodechallenge.presentation.util.MyFootMobTheme
 @Composable
 fun PlayerItem(
     player: Player,
-    onFollowClick: (Player) -> Unit
+    onFollowClick: (Player) -> Unit,
+    onClick: () -> Unit
 ) {
-    Card(
+    Row(
         modifier = Modifier
-            .fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(4.dp)
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier
-                .padding(8.dp)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column {
-                Text(
-                    text = player.name,
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = player.team.name,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = "Rank: ${player.team.rank}",
-                    style = MaterialTheme.typography.bodySmall
-                )
-            }
-            Button(onClick = { onFollowClick(player) }) {
-                Text(if (player.isFollowed) "Unfollow" else "Follow")
-            }
+        Column {
+            Text(player.name, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = "Team: ${player.team.name} • Goals: ${player.totalGoal}",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Button(onClick = { onFollowClick(player) }) {
+            Text(if (player.isFollowed) "Unfollow" else "Follow")
         }
     }
 }
@@ -61,8 +49,10 @@ fun PlayerItem(
 fun PreviewPlayerItem() {
     MyFootMobTheme {
         PlayerItem(
-            player = Player.sampleData
-        ) { }
+            player = Player.sampleData,
+            onFollowClick = {},
+            onClick = {}
+        )
     }
 }
 

--- a/app/src/main/java/ir/miare/androidcodechallenge/presentation/player_detail/PlayerDetailsContent.kt
+++ b/app/src/main/java/ir/miare/androidcodechallenge/presentation/player_detail/PlayerDetailsContent.kt
@@ -1,0 +1,64 @@
+package ir.miare.androidcodechallenge.presentation.player_detail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import ir.miare.androidcodechallenge.data.model.Player
+import ir.miare.androidcodechallenge.presentation.util.LightAndDarkPreview
+import ir.miare.androidcodechallenge.presentation.util.MyFootMobTheme
+
+@Composable
+fun PlayerDetailsContent(player: Player) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = player.name,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Team: ${player.team.name}",
+            style = MaterialTheme.typography.bodyLarge
+        )
+
+        Text(
+            text = "Total Goals: ${player.totalGoal}",
+            style = MaterialTheme.typography.bodyLarge
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(onClick = { }) {
+            Text(if (player.isFollowed) "Unfollow" else "Follow")
+        }
+    }
+}
+
+
+@LightAndDarkPreview
+@Composable
+fun PreviewPlayerDetailsContent() {
+    MyFootMobTheme {
+        PlayerDetailsContent(player = Player.sampleData)
+    }
+}
+
+
+


### PR DESCRIPTION
This commit introduces a modal bottom sheet to display player details when a player item is clicked in the ranking list.

Key changes:

- **Player Details UI:**
    - Created `PlayerDetailsContent.kt` composable to display player name, team, total goals, and a follow/unfollow button within the modal.
- **Ranking Screen (`RankingScreen.kt`):**
    - Implemented `ModalBottomSheet` to show player details.
    - Added state management (`selectedPlayer`, `showSheet`) to control the visibility and content of the bottom sheet.
    - When a player is clicked in `LeagueSection`, `selectedPlayer` is updated and `showSheet` is set to true to display the modal.
- **League Section (`LeagueSection.kt`):**
    - Added `onPlayerClick` lambda parameter to handle player item clicks.
    - Centered the league name and country text.
- **Player Item (`PlayerItem.kt`):**
    - Made the entire `Row` clickable to trigger the player detail view.
    - Removed `Card` usage and updated styling to a simpler `Row` with padding.
    - Updated display to show "Team: [TeamName] • Goals: [TotalGoals]".
- **Build Configuration:**
    - Incremented `versionCode` to 14 and `versionName` to "1.7.0".