### PR TITLE
Refactor:  Add tests and Extract FollowedPlayerRepository interface

### DIFF
--- a/app/src/main/java/ir/miare/androidcodechallenge/data/repository/FollowedPlayerRepositoryImpl.kt
+++ b/app/src/main/java/ir/miare/androidcodechallenge/data/repository/FollowedPlayerRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package ir.miare.androidcodechallenge.data.repository
+
+import ir.miare.androidcodechallenge.data.db.FollowedPlayerDao
+import ir.miare.androidcodechallenge.data.db.FollowedPlayerEntity
+import ir.miare.androidcodechallenge.data.model.League
+import ir.miare.androidcodechallenge.data.model.Player
+import ir.miare.androidcodechallenge.domain.repository.FollowedPlayerRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class FollowedPlayerRepositoryImpl @Inject constructor(
+    private val dao: FollowedPlayerDao
+) : FollowedPlayerRepository {
+
+    override fun getFollowedPlayers(): Flow<List<FollowedPlayerEntity>> =
+        dao.getFollowedPlayers()
+
+    override suspend fun follow(player: Player, league: League) {
+        dao.insert(
+            FollowedPlayerEntity(
+                playerName = player.name,
+                totalGoal = player.totalGoal,
+                teamName = player.team.name,
+                teamRank = player.team.rank,
+                leagueName = league.name,
+                leagueCountry = league.country,
+                leagueRank = league.rank,
+                leagueTotalMatches = league.totalMatches
+            )
+        )
+    }
+
+    override suspend fun unfollow(playerName: String) {
+        dao.deleteByName(playerName)
+    }
+
+    override suspend fun isFollowed(playerName: String): Boolean {
+        return dao.isFollowed(playerName)
+    }
+}

--- a/app/src/main/java/ir/miare/androidcodechallenge/di/RepositoryModule.kt
+++ b/app/src/main/java/ir/miare/androidcodechallenge/di/RepositoryModule.kt
@@ -1,0 +1,18 @@
+package ir.miare.androidcodechallenge.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import ir.miare.androidcodechallenge.data.repository.FollowedPlayerRepositoryImpl
+import ir.miare.androidcodechallenge.domain.repository.FollowedPlayerRepository
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    abstract fun bindFollowedPlayerRepository(
+        impl: FollowedPlayerRepositoryImpl
+    ): FollowedPlayerRepository
+}

--- a/app/src/main/java/ir/miare/androidcodechallenge/domain/repository/FollowedPlayerRepository.kt
+++ b/app/src/main/java/ir/miare/androidcodechallenge/domain/repository/FollowedPlayerRepository.kt
@@ -1,39 +1,13 @@
 package ir.miare.androidcodechallenge.domain.repository
 
-import ir.miare.androidcodechallenge.data.db.FollowedPlayerDao
 import ir.miare.androidcodechallenge.data.db.FollowedPlayerEntity
 import ir.miare.androidcodechallenge.data.model.League
 import ir.miare.androidcodechallenge.data.model.Player
 import kotlinx.coroutines.flow.Flow
-import javax.inject.Inject
 
-class FollowedPlayerRepository @Inject constructor(
-    private val dao: FollowedPlayerDao
-) {
-
-    fun getFollowedPlayers(): Flow<List<FollowedPlayerEntity>> =
-        dao.getFollowedPlayers()
-
-    suspend fun follow(player: Player, league: League) {
-        dao.insert(
-            FollowedPlayerEntity(
-                playerName = player.name,
-                totalGoal = player.totalGoal,
-                teamName = player.team.name,
-                teamRank = player.team.rank,
-                leagueName = league.name,
-                leagueCountry = league.country,
-                leagueRank = league.rank,
-                leagueTotalMatches = league.totalMatches
-            )
-        )
-    }
-
-    suspend fun unfollow(playerName: String) {
-        dao.deleteByName(playerName)
-    }
-
-    suspend fun isFollowed(playerName: String): Boolean {
-        return dao.isFollowed(playerName)
-    }
+interface FollowedPlayerRepository {
+    fun getFollowedPlayers(): Flow<List<FollowedPlayerEntity>>
+    suspend fun follow(player: Player, league: League)
+    suspend fun unfollow(playerName: String)
+    suspend fun isFollowed(playerName: String): Boolean
 }

--- a/app/src/test/java/ir/miare/androidcodechallenge/MainDispatcherRule.kt
+++ b/app/src/test/java/ir/miare/androidcodechallenge/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package ir.miare.androidcodechallenge
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/ir/miare/androidcodechallenge/data/FakeFollowedPlayerRepository.kt
+++ b/app/src/test/java/ir/miare/androidcodechallenge/data/FakeFollowedPlayerRepository.kt
@@ -1,0 +1,40 @@
+package ir.miare.androidcodechallenge.data
+
+import ir.miare.androidcodechallenge.data.db.FollowedPlayerEntity
+import ir.miare.androidcodechallenge.data.model.League
+import ir.miare.androidcodechallenge.data.model.Player
+import ir.miare.androidcodechallenge.domain.repository.FollowedPlayerRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+
+class FakeFollowedPlayerRepository : FollowedPlayerRepository {
+    private val _players = mutableListOf<FollowedPlayerEntity>()
+    private val _playersFlow = MutableStateFlow<List<FollowedPlayerEntity>>(emptyList())
+
+    override fun getFollowedPlayers(): Flow<List<FollowedPlayerEntity>> = _playersFlow
+
+    override suspend fun follow(player: Player, league: League) {
+        val entity = FollowedPlayerEntity(
+            playerName = player.name,
+            totalGoal = player.totalGoal,
+            teamName = player.team.name,
+            teamRank = player.team.rank,
+            leagueName = league.name,
+            leagueCountry = league.country,
+            leagueRank = league.rank,
+            leagueTotalMatches = league.totalMatches
+        )
+        _players.add(entity)
+        _playersFlow.value = _players.toList() // update synchronously
+    }
+
+    override suspend fun unfollow(playerName: String) {
+        _players.removeAll { it.playerName == playerName }
+        _playersFlow.value = _players.toList() // update synchronously
+    }
+
+    override suspend fun isFollowed(playerName: String): Boolean {
+        return _players.any { it.playerName == playerName } // reads _players directly
+    }
+}

--- a/app/src/test/java/ir/miare/androidcodechallenge/data/FakeLeagueRepository.kt
+++ b/app/src/test/java/ir/miare/androidcodechallenge/data/FakeLeagueRepository.kt
@@ -1,0 +1,49 @@
+package ir.miare.androidcodechallenge.data
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import ir.miare.androidcodechallenge.data.model.LeagueData
+import ir.miare.androidcodechallenge.domain.repository.LeagueRepository
+import ir.miare.androidcodechallenge.presentation.league_data_list.RankingSort
+
+class FakeLeagueRepository(
+    private val leagues: List<LeagueData>
+) : LeagueRepository {
+
+    override fun getLeaguePager(pageSize: Int, sort: RankingSort): Pager<Int, LeagueData> {
+        return Pager(
+            config = PagingConfig(pageSize = pageSize, enablePlaceholders = false),
+            pagingSourceFactory = {
+                object : PagingSource<Int, LeagueData>() {
+                    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, LeagueData> {
+                        val sortedLeagues = when (sort) {
+                            RankingSort.None -> leagues
+                            RankingSort.ByTeam -> leagues.map { it.copy(players = it.players.sortedBy { p -> p.team.name }) }
+                            RankingSort.ByLeagueRanking -> leagues.sortedBy { it.league.rank }
+                            RankingSort.ByMostGoals -> leagues.map { it.copy(players = it.players.sortedByDescending { p -> p.totalGoal }) }
+                            RankingSort.ByAverageGoalsPerMatch -> leagues.sortedByDescending { l ->
+                                val totalGoals = l.players.sumOf { it.totalGoal }
+                                if (l.league.totalMatches > 0) totalGoals.toDouble() / l.league.totalMatches else 0.0
+                            }
+                        }
+
+                        val page = params.key ?: 0
+                        val fromIndex = page * pageSize
+                        val toIndex = minOf(fromIndex + pageSize, sortedLeagues.size)
+                        val data = sortedLeagues.subList(fromIndex, toIndex)
+
+                        return LoadResult.Page(
+                            data = data,
+                            prevKey = if (page == 0) null else page - 1,
+                            nextKey = if (toIndex < sortedLeagues.size) page + 1 else null
+                        )
+                    }
+
+                    override fun getRefreshKey(state: PagingState<Int, LeagueData>): Int? = null
+                }
+            }
+        )
+    }
+}

--- a/app/src/test/java/ir/miare/androidcodechallenge/domain/use_case/FollowPlayerUseCaseTest.kt
+++ b/app/src/test/java/ir/miare/androidcodechallenge/domain/use_case/FollowPlayerUseCaseTest.kt
@@ -1,0 +1,33 @@
+package ir.miare.androidcodechallenge.domain.use_case
+
+import ir.miare.androidcodechallenge.data.FakeFollowedPlayerRepository
+import ir.miare.androidcodechallenge.data.model.League
+import ir.miare.androidcodechallenge.data.model.Player
+import ir.miare.androidcodechallenge.data.model.Team
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FollowPlayerUseCaseTest {
+
+    private lateinit var repository: FakeFollowedPlayerRepository
+    private lateinit var useCase: FollowPlayerUseCase
+    private val messi = Player("Messi", Team("PSG", 1), 30, false)
+    private val league = League("Ligue 1", "France", 1, 38)
+
+    @Before
+    fun setup() {
+        repository = FakeFollowedPlayerRepository()
+        useCase = FollowPlayerUseCase(repository)
+    }
+
+    @Test
+    fun `follow adds player to repository`() = runTest {
+        useCase(messi, league)
+        val stored = repository.getFollowedPlayers().first()
+        assert(stored.any { it.playerName == "Messi" })
+    }
+}

--- a/app/src/test/java/ir/miare/androidcodechallenge/domain/use_case/IsPlayerFollowedUseCaseTest.kt
+++ b/app/src/test/java/ir/miare/androidcodechallenge/domain/use_case/IsPlayerFollowedUseCaseTest.kt
@@ -1,0 +1,36 @@
+package ir.miare.androidcodechallenge.domain.use_case
+
+import ir.miare.androidcodechallenge.data.FakeFollowedPlayerRepository
+import ir.miare.androidcodechallenge.data.model.League
+import ir.miare.androidcodechallenge.data.model.Player
+import ir.miare.androidcodechallenge.data.model.Team
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IsPlayerFollowedUseCaseTest {
+
+    private lateinit var repository: FakeFollowedPlayerRepository
+    private lateinit var useCase: IsPlayerFollowedUseCase
+    private val messi = Player("Messi", Team("PSG", 1), 30, false)
+    private val league = League("Ligue 1", "France", 1, 38)
+
+    @Before
+    fun setup() {
+        repository = FakeFollowedPlayerRepository()
+        useCase = IsPlayerFollowedUseCase(repository)
+    }
+
+    @Test
+    fun `returns true when player is followed`() = runTest {
+        repository.follow(messi, league)
+        assert(useCase("Messi"))
+    }
+
+    @Test
+    fun `returns false when player is not followed`() = runTest {
+        assert(useCase("Messi").not())
+    }
+}

--- a/app/src/test/java/ir/miare/androidcodechallenge/domain/use_case/UnfollowPlayerUseCaseTest.kt
+++ b/app/src/test/java/ir/miare/androidcodechallenge/domain/use_case/UnfollowPlayerUseCaseTest.kt
@@ -1,0 +1,34 @@
+package ir.miare.androidcodechallenge.domain.use_case
+
+import ir.miare.androidcodechallenge.data.FakeFollowedPlayerRepository
+import ir.miare.androidcodechallenge.data.model.League
+import ir.miare.androidcodechallenge.data.model.Player
+import ir.miare.androidcodechallenge.data.model.Team
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UnfollowPlayerUseCaseTest {
+
+    private lateinit var repository: FakeFollowedPlayerRepository
+    private lateinit var useCase: UnfollowPlayerUseCase
+    private val messi = Player("Messi", Team("PSG", 1), 30, false)
+    private val league = League("Ligue 1", "France", 1, 38)
+
+    @Before
+    fun setup() {
+        repository = FakeFollowedPlayerRepository()
+        useCase = UnfollowPlayerUseCase(repository)
+    }
+
+    @Test
+    fun `unfollow removes player from repository`() = runTest {
+        repository.follow(messi, league)
+        assert(repository.isFollowed("Messi"))
+
+        useCase("Messi")
+        assert(!repository.isFollowed("Messi"))
+    }
+}

--- a/app/src/test/java/ir/miare/androidcodechallenge/presentation/league_data_list/RankingViewModelTest.kt
+++ b/app/src/test/java/ir/miare/androidcodechallenge/presentation/league_data_list/RankingViewModelTest.kt
@@ -1,0 +1,100 @@
+package ir.miare.androidcodechallenge.presentation.league_data_list
+
+import ir.miare.androidcodechallenge.MainDispatcherRule
+import ir.miare.androidcodechallenge.data.FakeFollowedPlayerRepository
+import ir.miare.androidcodechallenge.data.FakeLeagueRepository
+import ir.miare.androidcodechallenge.data.model.League
+import ir.miare.androidcodechallenge.data.model.LeagueData
+import ir.miare.androidcodechallenge.data.model.Player
+import ir.miare.androidcodechallenge.data.model.Team
+import ir.miare.androidcodechallenge.domain.use_case.FollowPlayerUseCase
+import ir.miare.androidcodechallenge.domain.use_case.GetFollowedPlayersUseCase
+import ir.miare.androidcodechallenge.domain.use_case.GetLeagueDataUseCase
+import ir.miare.androidcodechallenge.domain.use_case.IsPlayerFollowedUseCase
+import ir.miare.androidcodechallenge.domain.use_case.UnfollowPlayerUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RankingViewModelTest {
+
+    private lateinit var followedRepo: FakeFollowedPlayerRepository
+    private lateinit var leagueRepo: FakeLeagueRepository
+    private lateinit var viewModel: RankingViewModel
+
+    private val messi = Player("Messi", Team("PSG", 1), 30, false)
+    private val league = League("Ligue 1", "France", 1, 38)
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule() // sets Dispatchers.Main to TestDispatcher
+
+    @Before
+    fun setup() {
+        followedRepo = FakeFollowedPlayerRepository() // fresh repo
+        leagueRepo = FakeLeagueRepository(
+            leagues = listOf(
+                LeagueData(
+                    league = league,
+                    players = listOf(messi)
+                )
+            )
+        )
+
+        viewModel = RankingViewModel(
+            getLeagueDataUseCase = GetLeagueDataUseCase(leagueRepo),
+            getFollowedPlayersUseCase = GetFollowedPlayersUseCase(followedRepo),
+            isPlayerFollowedUseCase = IsPlayerFollowedUseCase(followedRepo),
+            followPlayerUseCase = FollowPlayerUseCase(followedRepo),
+            unfollowPlayerUseCase = UnfollowPlayerUseCase(followedRepo)
+        )
+    }
+
+    @Test
+    fun `FollowClicked adds player to repository`() = runTest {
+        viewModel.onEvent(RankingEvent.FollowClicked(messi, league))
+        advanceUntilIdle()
+        assert(followedRepo.isFollowed(messi.name))
+    }
+
+    @Test
+    fun `FollowClicked toggles player correctly`() = runTest {
+        // prefill
+        followedRepo.follow(messi, league)
+        assert(followedRepo.isFollowed(messi.name))
+
+        // first click → unfollow
+        viewModel.onEvent(RankingEvent.FollowClicked(messi, league))
+        advanceUntilIdle()
+        assert(followedRepo.isFollowed(messi.name).not())
+
+        // second click → follow
+        viewModel.onEvent(RankingEvent.FollowClicked(messi, league))
+        advanceUntilIdle()
+        assert(followedRepo.isFollowed(messi.name))
+    }
+
+    @Test
+    fun `SortChanged updates uiState`() = runTest {
+        viewModel.onEvent(RankingEvent.SortChanged(RankingSort.ByMostGoals))
+        assert(viewModel.uiState.value.sort == RankingSort.ByMostGoals)
+    }
+
+    @Test
+    fun `PlayerClicked updates uiState with selected player`() = runTest {
+        viewModel.onEvent(RankingEvent.PlayerClicked(messi))
+        assert(viewModel.uiState.value.selectedPlayer == messi)
+        assert(viewModel.uiState.value.showSheet)
+    }
+
+    @Test
+    fun `SheetDismissed clears selected player`() = runTest {
+        viewModel.onEvent(RankingEvent.PlayerClicked(messi))
+        viewModel.onEvent(RankingEvent.SheetDismissed)
+        assert(viewModel.uiState.value.selectedPlayer == null)
+        assert(!viewModel.uiState.value.showSheet)
+    }
+}


### PR DESCRIPTION
This commit introduces an interface for `FollowedPlayerRepository` and implements it with `FollowedPlayerRepositoryImpl`. This change facilitates testing by allowing the use of a fake repository implementation.

Key changes:
- **Repository Interface:**
    - Created `FollowedPlayerRepository` interface defining the contract for managing followed players.
    - Updated `FollowedPlayerRepositoryImpl` to implement the new interface.
- **Dependency Injection:**
    - Added `RepositoryModule` to bind `FollowedPlayerRepositoryImpl` to the `FollowedPlayerRepository` interface for Hilt.
- **Testing:**
    - Added `FakeFollowedPlayerRepository` for testing purposes.
    - Added `MainDispatcherRule` to manage coroutine dispatchers in tests.
    - Implemented unit tests for:
        - `FollowPlayerUseCase`
        - `IsPlayerFollowedUseCase` - `UnfollowPlayerUseCase` - `RankingViewModel`
    - Added `FakeLeagueRepository` for testing `RankingViewModel` and league-related use cases.